### PR TITLE
Fix Stai template binary name

### DIFF
--- a/blockchain/stai.json.template
+++ b/blockchain/stai.json.template
@@ -1,5 +1,5 @@
 {
-    "Binary Name": "staicoin",
+    "Binary Name": "stai",
     "Currency Symbol": "STAI",
     "Minor Currency Symbol": "mojo",
     "Major to Minor Multiplier": 1e9,


### PR DESCRIPTION
I noticed the stai binary name is wrong in the template.
I verified that this fixes the issue by:
- Cloning the Stai repo and building
- Installing the Stai binary
Both on ubuntu.